### PR TITLE
react: add size options to connect modal

### DIFF
--- a/.changeset/slow-buttons-serve.md
+++ b/.changeset/slow-buttons-serve.md
@@ -1,0 +1,5 @@
+---
+"@treasure-dev/tdk-react": patch
+---
+
+Added size options to Treasure Connect modal

--- a/package-lock.json
+++ b/package-lock.json
@@ -37137,7 +37137,7 @@
     },
     "packages/core": {
       "name": "@treasure-dev/tdk-core",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "dependencies": {
         "@sushiswap/tines": "^1.0.3",
         "@wagmi/core": "^2.9.1",
@@ -37153,7 +37153,7 @@
     },
     "packages/react": {
       "name": "@treasure-dev/tdk-react",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-visually-hidden": "^1.1.0",

--- a/packages/react/src/components/connect/ConnectModal.stories.tsx
+++ b/packages/react/src/components/connect/ConnectModal.stories.tsx
@@ -11,14 +11,14 @@ export default meta;
 type Story = StoryObj<typeof ConnectModal>;
 
 export const Default: Story = {
-  render: () => {
+  render: (args) => {
     const [open, setOpen] = useState(false);
     return (
       <>
         <button type="button" onClick={() => setOpen(true)}>
           Open Connect Modal
         </button>
-        <ConnectModal open={open} onOpenChange={setOpen} />
+        <ConnectModal {...args} open={open} onOpenChange={setOpen} />
       </>
     );
   },

--- a/packages/react/src/components/connect/ConnectModal.tsx
+++ b/packages/react/src/components/connect/ConnectModal.tsx
@@ -14,6 +14,7 @@ import type { Wallet } from "thirdweb/wallets";
 import { Trans, useTranslation } from "react-i18next";
 import { useTreasure } from "../../contexts/treasure";
 import { getLocaleId } from "../../i18n";
+import { cn } from "../../utils/classnames";
 import { Dialog, DialogContent, DialogTitle } from "../ui/Dialog";
 import {
   type Options as ConnectMethodSelectionOptions,
@@ -27,8 +28,9 @@ export type Options = ConnectMethodSelectionOptions & {
   redirectExternally?: boolean;
 };
 
-type Props = Options & {
+export type Props = Options & {
   open: boolean;
+  size?: "lg" | "xl" | "2xl" | "3xl";
   onOpenChange: (open: boolean) => void;
 };
 
@@ -40,6 +42,7 @@ const DEFAULT_STATE = {
 
 export const ConnectModal = ({
   open,
+  size = "lg",
   authMode,
   redirectUrl,
   redirectExternally,
@@ -220,7 +223,15 @@ export const ConnectModal = ({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="tdk-max-w-lg" aria-describedby={undefined}>
+      <DialogContent
+        className={cn(
+          size === "lg" && "tdk-max-w-lg",
+          size === "xl" && "tdk-max-w-xl",
+          size === "2xl" && "tdk-max-w-2xl",
+          size === "3xl" && "tdk-max-w-3xl",
+        )}
+        aria-describedby={undefined}
+      >
         <VisuallyHidden.Root>
           <DialogTitle>
             {email ? (

--- a/packages/react/src/hooks/useConnect.tsx
+++ b/packages/react/src/hooks/useConnect.tsx
@@ -9,12 +9,14 @@ import { ZERO_ADDRESS, defineChain } from "thirdweb";
 import {
   ConnectModal,
   type Options as ConnectModalOptions,
+  type Props as ConnectModalProps,
 } from "../components/connect/ConnectModal";
 import { useTreasure } from "../contexts/treasure";
 import { getLocaleId } from "../i18n";
 
 export type Options = ConnectModalOptions & {
   supportedChainIds?: number[];
+  connectModalSize?: ConnectModalProps["size"];
 };
 
 type Props = Options;
@@ -59,7 +61,8 @@ const SUPPORTED_TOKENS = [
 export const useConnect = (props?: Props) => {
   const { chain, client, logOut, setRootElement } = useTreasure();
   const { open: openWalletDetailsModal } = useWalletDetailsModal();
-  const { supportedChainIds, ...connectModalProps } = props ?? {};
+  const { supportedChainIds, connectModalSize, ...connectModalProps } =
+    props ?? {};
 
   const chains =
     supportedChainIds && supportedChainIds.length > 0
@@ -70,6 +73,7 @@ export const useConnect = (props?: Props) => {
     setRootElement(
       <ConnectModal
         open
+        size={connectModalSize}
         onOpenChange={() => setRootElement(null)}
         {...connectModalProps}
       />,


### PR DESCRIPTION
Adds size options to the Treasure Connect modal to allow it to grow to larger widths if desired


https://github.com/user-attachments/assets/1dbc80d1-f3d9-482b-b17d-98669c74fb4c

