### PR TITLE
react: add option for custom auto-connect timeout

### DIFF
--- a/.changeset/fifty-forks-knock.md
+++ b/.changeset/fifty-forks-knock.md
@@ -1,0 +1,5 @@
+---
+"@treasure-dev/tdk-react": patch
+---
+
+Added option for custom auto-connect timeout

--- a/packages/react/src/contexts/treasure.tsx
+++ b/packages/react/src/contexts/treasure.tsx
@@ -51,6 +51,7 @@ type Config = {
   defaultChainId?: number;
   clientId: string;
   sessionOptions?: SessionOptions;
+  autoConnectTimeout?: number;
   onConnect?: (user: User) => void;
 };
 
@@ -94,6 +95,7 @@ const TreasureProviderInner = ({
   defaultChainId = DEFAULT_TDK_CHAIN_ID,
   clientId,
   sessionOptions,
+  autoConnectTimeout = 5_000,
   onConnect,
 }: Props) => {
   const [isAuthenticating, setIsAuthenticating] = useState(false);
@@ -190,7 +192,7 @@ const TreasureProviderInner = ({
       factoryAddress: contractAddresses.ManagedAccountFactory,
       sponsorGas: true,
     },
-    timeout: 5_000,
+    timeout: autoConnectTimeout,
     onConnect: async (wallet) => {
       setIsAuthenticating(true);
       try {


### PR DESCRIPTION
Adds option to pass custom timeout for the `TreasureProvider`'s auto-connect feature (defaults to 5s)