### PR TITLE
add optional passkey configs and callbacks to connect hooks, components and utils

### DIFF
--- a/.changeset/shaggy-emus-smell.md
+++ b/.changeset/shaggy-emus-smell.md
@@ -1,0 +1,5 @@
+---
+"@treasure-dev/tdk-core": patch
+---
+
+Added connect with passkey param to override sign in type

--- a/.changeset/short-oranges-stare.md
+++ b/.changeset/short-oranges-stare.md
@@ -1,0 +1,5 @@
+---
+"@treasure-dev/tdk-react": patch
+---
+
+Added connect success and error callbacks

--- a/examples/connect-react/src/App.tsx
+++ b/examples/connect-react/src/App.tsx
@@ -69,7 +69,15 @@ export const App = () => {
         <h1 className="font-semibold text-2xl text-ruby">
           TDK React - Connect Example
         </h1>
-        <ConnectButton supportedChainIds={[421614, 42161]} />
+        <ConnectButton
+          supportedChainIds={[421614, 42161]}
+          onConnected={(method, wallet) => {
+            console.log("Connect successful:", { method, wallet });
+          }}
+          onConnectError={(method, err) => {
+            console.log("Connect failed:", { method, err });
+          }}
+        />
       </header>
       <main className="space-y-6">
         {user ? (

--- a/packages/core/src/connect/login.test.ts
+++ b/packages/core/src/connect/login.test.ts
@@ -1,4 +1,3 @@
-//
 import { describe, expect, it } from "vitest";
 import { createLoginUrl, isSocialConnectMethod } from "./login";
 

--- a/packages/core/src/connect/login.ts
+++ b/packages/core/src/connect/login.ts
@@ -60,6 +60,7 @@ type ConnectWalletConfig = {
   | {
       method: "passkey";
       passkeyName?: string;
+      hasStoredPasskey?: boolean;
     }
 );
 
@@ -105,7 +106,8 @@ export const connectWallet = async (params: ConnectWalletConfig) => {
 
   // Connect with passkey
   if (params.method === "passkey") {
-    const hasPasskey = await hasStoredPasskey(client);
+    const hasPasskey =
+      params.hasStoredPasskey ?? (await hasStoredPasskey(client));
     await wallet.connect({
       client,
       chain,

--- a/packages/react/src/components/connect/ConnectModal.tsx
+++ b/packages/react/src/components/connect/ConnectModal.tsx
@@ -28,6 +28,8 @@ import { ConnectVerifyCodeView } from "./ConnectVerifyCodeView";
 export type Options = ConnectMethodSelectionOptions & {
   authMode?: "popup" | "redirect";
   redirectUrl?: string;
+  passkeyDomain?: string;
+  passkeyName?: string;
   hasStoredPasskey?: boolean;
 };
 
@@ -48,6 +50,8 @@ export const ConnectModal = ({
   size = "lg",
   authMode,
   redirectUrl,
+  passkeyDomain,
+  passkeyName,
   hasStoredPasskey,
   onOpenChange,
   ...methodSelectionProps
@@ -204,7 +208,11 @@ export const ConnectModal = ({
           method,
           authMode: "popup",
           redirectUrl,
-          ...(method === "passkey" && { hasStoredPasskey }),
+          ...(method === "passkey" && {
+            passkeyDomain,
+            passkeyName,
+            hasStoredPasskey,
+          }),
         });
         wallet = await connect(inAppWallet);
       } catch (err) {

--- a/packages/react/src/components/connect/ConnectModal.tsx
+++ b/packages/react/src/components/connect/ConnectModal.tsx
@@ -28,6 +28,7 @@ import { ConnectVerifyCodeView } from "./ConnectVerifyCodeView";
 export type Options = ConnectMethodSelectionOptions & {
   authMode?: "popup" | "redirect";
   redirectUrl?: string;
+  hasStoredPasskey?: boolean;
 };
 
 export type Props = Options & {
@@ -47,6 +48,7 @@ export const ConnectModal = ({
   size = "lg",
   authMode,
   redirectUrl,
+  hasStoredPasskey,
   onOpenChange,
   ...methodSelectionProps
 }: Props) => {
@@ -202,6 +204,7 @@ export const ConnectModal = ({
           method,
           authMode: "popup",
           redirectUrl,
+          ...(method === "passkey" && { hasStoredPasskey }),
         });
         wallet = await connect(inAppWallet);
       } catch (err) {

--- a/packages/react/src/utils/error.test.ts
+++ b/packages/react/src/utils/error.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { getErrorMessage } from "./error";
+
+class MockCustomError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "MockCustomError";
+  }
+}
+
+describe("error utils", () => {
+  it("should get error message", () => {
+    expect(getErrorMessage(new Error("test"))).toBe("test");
+    expect(getErrorMessage("test")).toBe("test");
+    expect(getErrorMessage(new MockCustomError("test"))).toBe("test");
+  });
+});

--- a/packages/react/src/utils/error.ts
+++ b/packages/react/src/utils/error.ts
@@ -1,0 +1,2 @@
+export const getErrorMessage = (err: unknown) =>
+  err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
- Adds optional `hasStoredPasskey` param when connecting with passkey to override the built-in storage check. The storage check currently uses web localstorage only, which is not valid in an Electron app.
- Adds optional `passkeyDomain` and `passkeyName` params to React hooks and components
- Adds optional `onConnected` and `onConnectError` callback params to React hooks and components