### PR TITLE
Fix tx overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -232,8 +232,8 @@ crash.log
 crash.*.log
 
 # Exclude all .tfvars files, which are likely to contain sensitive data, such as
-# password, private keys, and other secrets. These should not be part of version 
-# control as they are data points which are potentially sensitive and subject 
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
 # to change depending on the environment.
 *.tfvars
 *.tfvars.json
@@ -258,3 +258,6 @@ terraform.rc
 # Ignore CLI configuration files
 .vscode
 *storybook.log
+
+# IntelliJ
+.idea

--- a/apps/api/src/routes/transactions.ts
+++ b/apps/api/src/routes/transactions.ts
@@ -90,8 +90,8 @@ export const transactionsRoutes =
             typeof abi === "string" && abi.length > 0
               ? JSON.parse(abi)
               : Array.isArray(abi) && abi.length > 0
-              ? abi
-              : undefined;
+                ? abi
+                : undefined;
 
           Sentry.setExtra(
             "transaction",
@@ -103,8 +103,8 @@ export const transactionsRoutes =
                 args,
               },
               null,
-              2
-            )
+              2,
+            ),
           );
 
           const parsedTxOverrides = parseTxOverrides(txOverrides);
@@ -122,7 +122,7 @@ export const transactionsRoutes =
             simulateTransaction,
             undefined,
             userAddress,
-            getContractAddress(chain.id, "ManagedAccountFactory")
+            getContractAddress(chain.id, "ManagedAccountFactory"),
           );
           reply.send(result);
         } catch (err) {
@@ -132,7 +132,7 @@ export const transactionsRoutes =
             message: parseEngineErrorMessage(err),
           });
         }
-      }
+      },
     );
 
     app.post<{
@@ -193,7 +193,7 @@ export const transactionsRoutes =
             simulateTransaction,
             undefined,
             userAddress,
-            getContractAddress(chain.id, "ManagedAccountFactory")
+            getContractAddress(chain.id, "ManagedAccountFactory"),
           );
           reply.send(result);
         } catch (err) {
@@ -203,7 +203,7 @@ export const transactionsRoutes =
             message: parseEngineErrorMessage(err),
           });
         }
-      }
+      },
     );
 
     app.get<{
@@ -261,6 +261,6 @@ export const transactionsRoutes =
             message: parseEngineErrorMessage(err),
           });
         }
-      }
+      },
     );
   };

--- a/apps/api/src/routes/transactions.ts
+++ b/apps/api/src/routes/transactions.ts
@@ -27,6 +27,7 @@ import {
   normalizeEngineErrorMessage,
   parseEngineErrorMessage,
 } from "../utils/error";
+import {parseTxOverrides} from "../utils/transaction";
 
 export const transactionsRoutes =
   ({ db, engine, env }: TdkApiContext): FastifyPluginAsync =>
@@ -106,6 +107,8 @@ export const transactionsRoutes =
             ),
           );
 
+          const parsedTxOverrides = parseTxOverrides(txOverrides);
+
           const { result } = await engine.contract.write(
             chain.id.toString(),
             address,
@@ -114,7 +117,7 @@ export const transactionsRoutes =
               abi: transactionAbi,
               functionName,
               args,
-              txOverrides,
+              txOverrides: parsedTxOverrides,
             },
             simulateTransaction,
             undefined,
@@ -174,6 +177,8 @@ export const transactionsRoutes =
           });
         }
 
+        const parsedTxOverrides = parseTxOverrides(txOverrides);
+
         try {
           Sentry.setExtra("transaction", { to, value, data });
           const { result } = await engine.backendWallet.sendTransaction(
@@ -183,7 +188,7 @@ export const transactionsRoutes =
               toAddress: to,
               value: value,
               data,
-              txOverrides,
+              txOverrides: parsedTxOverrides,
             },
             simulateTransaction,
             undefined,

--- a/apps/api/src/routes/transactions.ts
+++ b/apps/api/src/routes/transactions.ts
@@ -27,7 +27,7 @@ import {
   normalizeEngineErrorMessage,
   parseEngineErrorMessage,
 } from "../utils/error";
-import {parseTxOverrides} from "../utils/transaction";
+import { parseTxOverrides } from "../utils/transaction";
 
 export const transactionsRoutes =
   ({ db, engine, env }: TdkApiContext): FastifyPluginAsync =>
@@ -90,8 +90,8 @@ export const transactionsRoutes =
             typeof abi === "string" && abi.length > 0
               ? JSON.parse(abi)
               : Array.isArray(abi) && abi.length > 0
-                ? abi
-                : undefined;
+              ? abi
+              : undefined;
 
           Sentry.setExtra(
             "transaction",
@@ -103,8 +103,8 @@ export const transactionsRoutes =
                 args,
               },
               null,
-              2,
-            ),
+              2
+            )
           );
 
           const parsedTxOverrides = parseTxOverrides(txOverrides);
@@ -122,7 +122,7 @@ export const transactionsRoutes =
             simulateTransaction,
             undefined,
             userAddress,
-            getContractAddress(chain.id, "ManagedAccountFactory"),
+            getContractAddress(chain.id, "ManagedAccountFactory")
           );
           reply.send(result);
         } catch (err) {
@@ -132,7 +132,7 @@ export const transactionsRoutes =
             message: parseEngineErrorMessage(err),
           });
         }
-      },
+      }
     );
 
     app.post<{
@@ -193,7 +193,7 @@ export const transactionsRoutes =
             simulateTransaction,
             undefined,
             userAddress,
-            getContractAddress(chain.id, "ManagedAccountFactory"),
+            getContractAddress(chain.id, "ManagedAccountFactory")
           );
           reply.send(result);
         } catch (err) {
@@ -203,7 +203,7 @@ export const transactionsRoutes =
             message: parseEngineErrorMessage(err),
           });
         }
-      },
+      }
     );
 
     app.get<{
@@ -261,6 +261,6 @@ export const transactionsRoutes =
             message: parseEngineErrorMessage(err),
           });
         }
-      },
+      }
     );
   };

--- a/apps/api/src/utils/transaction.test.ts
+++ b/apps/api/src/utils/transaction.test.ts
@@ -22,7 +22,7 @@ describe("transaction utils", () => {
     });
 
     expect(
-      parseTxOverrides({ maxPriorityFeePerGas: "10000000000" })
+      parseTxOverrides({ maxPriorityFeePerGas: "10000000000" }),
     ).toStrictEqual({
       gas: undefined,
       maxFeePerGas: undefined,
@@ -43,7 +43,7 @@ describe("transaction utils", () => {
         maxFeePerGas: "10000000000",
         maxPriorityFeePerGas: "10000000000",
         value: "10000000000",
-      })
+      }),
     ).toStrictEqual({
       gas: "10000000000",
       maxFeePerGas: "10000000000",
@@ -57,7 +57,7 @@ describe("transaction utils", () => {
         maxFeePerGas: "10000000000",
         maxPriorityFeePerGas: "10000000000",
         value: "10000000000",
-      })
+      }),
     ).toStrictEqual({
       gas: undefined,
       maxFeePerGas: "10000000000",
@@ -71,7 +71,7 @@ describe("transaction utils", () => {
         maxFeePerGas: "10000000000",
         maxPriorityFeePerGas: null as unknown as string,
         value: "10000000000",
-      })
+      }),
     ).toStrictEqual({
       gas: undefined,
       maxFeePerGas: "10000000000",

--- a/apps/api/src/utils/transaction.test.ts
+++ b/apps/api/src/utils/transaction.test.ts
@@ -2,81 +2,81 @@ import { describe, expect, it } from "vitest";
 import { parseTxOverrides } from "./transaction";
 
 describe("transaction utils", () => {
-    it("should parse tx overrides", () => {
-        expect(parseTxOverrides()).toBeUndefined();
+  it("should parse tx overrides", () => {
+    expect(parseTxOverrides()).toBeUndefined();
 
-        expect(parseTxOverrides({})).toBeUndefined();
+    expect(parseTxOverrides({})).toBeUndefined();
 
-        expect(parseTxOverrides({ gas: "10000000000" })).toStrictEqual({
-            gas: "10000000000",
-            maxFeePerGas: undefined,
-            maxPriorityFeePerGas: undefined,
-            value: undefined,
-        });
-
-        expect(parseTxOverrides({ maxFeePerGas: "10000000000" })).toStrictEqual({
-            gas: undefined,
-            maxFeePerGas: "10000000000",
-            maxPriorityFeePerGas: undefined,
-            value: undefined,
-        });
-
-        expect(
-            parseTxOverrides({ maxPriorityFeePerGas: "10000000000" }),
-        ).toStrictEqual({
-            gas: undefined,
-            maxFeePerGas: undefined,
-            maxPriorityFeePerGas: "10000000000",
-            value: undefined,
-        });
-
-        expect(parseTxOverrides({ value: "10000000000" })).toStrictEqual({
-            gas: undefined,
-            maxFeePerGas: undefined,
-            maxPriorityFeePerGas: undefined,
-            value: "10000000000",
-        });
-
-        expect(
-            parseTxOverrides({
-                gas: "10000000000",
-                maxFeePerGas: "10000000000",
-                maxPriorityFeePerGas: "10000000000",
-                value: "10000000000",
-            }),
-        ).toStrictEqual({
-            gas: "10000000000",
-            maxFeePerGas: "10000000000",
-            maxPriorityFeePerGas: "10000000000",
-            value: "10000000000",
-        });
-
-        expect(
-            parseTxOverrides({
-                gas: "",
-                maxFeePerGas: "10000000000",
-                maxPriorityFeePerGas: "10000000000",
-                value: "10000000000",
-            }),
-        ).toStrictEqual({
-            gas: undefined,
-            maxFeePerGas: "10000000000",
-            maxPriorityFeePerGas: "10000000000",
-            value: "10000000000",
-        });
-
-        expect(
-            parseTxOverrides({
-                gas: null as unknown as string,
-                maxFeePerGas: "10000000000",
-                maxPriorityFeePerGas: null as unknown as string,
-                value: "10000000000",
-            }),
-        ).toStrictEqual({
-            gas: undefined,
-            maxFeePerGas: "10000000000",
-            maxPriorityFeePerGas: undefined,
-            value: "10000000000",
-        });
+    expect(parseTxOverrides({ gas: "10000000000" })).toStrictEqual({
+      gas: "10000000000",
+      maxFeePerGas: undefined,
+      maxPriorityFeePerGas: undefined,
+      value: undefined,
     });
+
+    expect(parseTxOverrides({ maxFeePerGas: "10000000000" })).toStrictEqual({
+      gas: undefined,
+      maxFeePerGas: "10000000000",
+      maxPriorityFeePerGas: undefined,
+      value: undefined,
+    });
+
+    expect(
+      parseTxOverrides({ maxPriorityFeePerGas: "10000000000" })
+    ).toStrictEqual({
+      gas: undefined,
+      maxFeePerGas: undefined,
+      maxPriorityFeePerGas: "10000000000",
+      value: undefined,
+    });
+
+    expect(parseTxOverrides({ value: "10000000000" })).toStrictEqual({
+      gas: undefined,
+      maxFeePerGas: undefined,
+      maxPriorityFeePerGas: undefined,
+      value: "10000000000",
+    });
+
+    expect(
+      parseTxOverrides({
+        gas: "10000000000",
+        maxFeePerGas: "10000000000",
+        maxPriorityFeePerGas: "10000000000",
+        value: "10000000000",
+      })
+    ).toStrictEqual({
+      gas: "10000000000",
+      maxFeePerGas: "10000000000",
+      maxPriorityFeePerGas: "10000000000",
+      value: "10000000000",
+    });
+
+    expect(
+      parseTxOverrides({
+        gas: "",
+        maxFeePerGas: "10000000000",
+        maxPriorityFeePerGas: "10000000000",
+        value: "10000000000",
+      })
+    ).toStrictEqual({
+      gas: undefined,
+      maxFeePerGas: "10000000000",
+      maxPriorityFeePerGas: "10000000000",
+      value: "10000000000",
+    });
+
+    expect(
+      parseTxOverrides({
+        gas: null as unknown as string,
+        maxFeePerGas: "10000000000",
+        maxPriorityFeePerGas: null as unknown as string,
+        value: "10000000000",
+      })
+    ).toStrictEqual({
+      gas: undefined,
+      maxFeePerGas: "10000000000",
+      maxPriorityFeePerGas: undefined,
+      value: "10000000000",
+    });
+  });
 });

--- a/apps/api/src/utils/transaction.test.ts
+++ b/apps/api/src/utils/transaction.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { parseTxOverrides } from "./transaction";
+
+describe("transaction utils", () => {
+    it("should parse tx overrides", () => {
+        expect(parseTxOverrides()).toBeUndefined();
+
+        expect(parseTxOverrides({})).toBeUndefined();
+
+        expect(parseTxOverrides({ gas: "10000000000" })).toStrictEqual({
+            gas: "10000000000",
+            maxFeePerGas: undefined,
+            maxPriorityFeePerGas: undefined,
+            value: undefined,
+        });
+
+        expect(parseTxOverrides({ maxFeePerGas: "10000000000" })).toStrictEqual({
+            gas: undefined,
+            maxFeePerGas: "10000000000",
+            maxPriorityFeePerGas: undefined,
+            value: undefined,
+        });
+
+        expect(
+            parseTxOverrides({ maxPriorityFeePerGas: "10000000000" }),
+        ).toStrictEqual({
+            gas: undefined,
+            maxFeePerGas: undefined,
+            maxPriorityFeePerGas: "10000000000",
+            value: undefined,
+        });
+
+        expect(parseTxOverrides({ value: "10000000000" })).toStrictEqual({
+            gas: undefined,
+            maxFeePerGas: undefined,
+            maxPriorityFeePerGas: undefined,
+            value: "10000000000",
+        });
+
+        expect(
+            parseTxOverrides({
+                gas: "10000000000",
+                maxFeePerGas: "10000000000",
+                maxPriorityFeePerGas: "10000000000",
+                value: "10000000000",
+            }),
+        ).toStrictEqual({
+            gas: "10000000000",
+            maxFeePerGas: "10000000000",
+            maxPriorityFeePerGas: "10000000000",
+            value: "10000000000",
+        });
+
+        expect(
+            parseTxOverrides({
+                gas: "",
+                maxFeePerGas: "10000000000",
+                maxPriorityFeePerGas: "10000000000",
+                value: "10000000000",
+            }),
+        ).toStrictEqual({
+            gas: undefined,
+            maxFeePerGas: "10000000000",
+            maxPriorityFeePerGas: "10000000000",
+            value: "10000000000",
+        });
+
+        expect(
+            parseTxOverrides({
+                gas: null as unknown as string,
+                maxFeePerGas: "10000000000",
+                maxPriorityFeePerGas: null as unknown as string,
+                value: "10000000000",
+            }),
+        ).toStrictEqual({
+            gas: undefined,
+            maxFeePerGas: "10000000000",
+            maxPriorityFeePerGas: undefined,
+            value: "10000000000",
+        });
+    });
+});

--- a/apps/api/src/utils/transaction.ts
+++ b/apps/api/src/utils/transaction.ts
@@ -10,7 +10,7 @@ import type {
 import type { TransactionArguments, TransactionOverrides } from "../schema";
 
 export const parseTxOverrides = (
-  txOverrides?: TransactionOverrides
+  txOverrides?: TransactionOverrides,
 ): TransactionOverrides | undefined => {
   const gas = txOverrides?.gas ? txOverrides.gas : undefined;
   const maxFeePerGas = txOverrides?.maxFeePerGas
@@ -36,7 +36,7 @@ export const writeTransaction = async <
   TFunctionName extends ExtractAbiFunctionNames<
     TAbi,
     "nonpayable" | "payable"
-  > = string
+  > = string,
 >({
   engine,
   chainId,
@@ -83,8 +83,8 @@ export const writeTransaction = async <
         args,
       },
       null,
-      2
-    )
+      2,
+    ),
   );
 
   const parsedTxOverrides = parseTxOverrides(txOverrides);
@@ -103,7 +103,7 @@ export const writeTransaction = async <
     },
     simulateTransaction,
     idempotencyKey,
-    smartAccountAddress
+    smartAccountAddress,
   );
   return result;
 };

--- a/apps/api/src/utils/transaction.ts
+++ b/apps/api/src/utils/transaction.ts
@@ -9,6 +9,22 @@ import type {
 
 import type { TransactionArguments, TransactionOverrides } from "../schema";
 
+export const parseTxOverrides = (txOverrides?: TransactionOverrides): TransactionOverrides | undefined => {
+    const gas = txOverrides?.gas ? txOverrides.gas : undefined;
+    const maxFeePerGas = txOverrides?.maxFeePerGas ? txOverrides.maxFeePerGas : undefined;
+    const maxPriorityFeePerGas = txOverrides?.maxPriorityFeePerGas ? txOverrides.maxPriorityFeePerGas : undefined;
+    const value = txOverrides?.value ? txOverrides.value : undefined;
+    if (gas || maxFeePerGas || maxPriorityFeePerGas || value) {
+        return {
+            gas,
+            maxFeePerGas,
+            maxPriorityFeePerGas,
+            value
+        }
+    }
+    return undefined;
+}
+
 export const writeTransaction = async <
   TAbi extends Abi,
   TFunctionName extends ExtractAbiFunctionNames<
@@ -64,6 +80,9 @@ export const writeTransaction = async <
       2,
     ),
   );
+
+  const parsedTxOverrides = parseTxOverrides(txOverrides);
+
   const { result } = await engine.contract.write(
     chainId.toString(),
     contractAddress,
@@ -74,7 +93,7 @@ export const writeTransaction = async <
       functionName,
       // @ts-ignore: stronger type-checking than Engine
       args,
-      txOverrides,
+      txOverrides: parsedTxOverrides,
     },
     simulateTransaction,
     idempotencyKey,

--- a/apps/api/src/utils/transaction.ts
+++ b/apps/api/src/utils/transaction.ts
@@ -9,28 +9,34 @@ import type {
 
 import type { TransactionArguments, TransactionOverrides } from "../schema";
 
-export const parseTxOverrides = (txOverrides?: TransactionOverrides): TransactionOverrides | undefined => {
-    const gas = txOverrides?.gas ? txOverrides.gas : undefined;
-    const maxFeePerGas = txOverrides?.maxFeePerGas ? txOverrides.maxFeePerGas : undefined;
-    const maxPriorityFeePerGas = txOverrides?.maxPriorityFeePerGas ? txOverrides.maxPriorityFeePerGas : undefined;
-    const value = txOverrides?.value ? txOverrides.value : undefined;
-    if (gas || maxFeePerGas || maxPriorityFeePerGas || value) {
-        return {
-            gas,
-            maxFeePerGas,
-            maxPriorityFeePerGas,
-            value
-        }
-    }
-    return undefined;
-}
+export const parseTxOverrides = (
+  txOverrides?: TransactionOverrides
+): TransactionOverrides | undefined => {
+  const gas = txOverrides?.gas ? txOverrides.gas : undefined;
+  const maxFeePerGas = txOverrides?.maxFeePerGas
+    ? txOverrides.maxFeePerGas
+    : undefined;
+  const maxPriorityFeePerGas = txOverrides?.maxPriorityFeePerGas
+    ? txOverrides.maxPriorityFeePerGas
+    : undefined;
+  const value = txOverrides?.value ? txOverrides.value : undefined;
+  if (gas || maxFeePerGas || maxPriorityFeePerGas || value) {
+    return {
+      gas,
+      maxFeePerGas,
+      maxPriorityFeePerGas,
+      value,
+    };
+  }
+  return undefined;
+};
 
 export const writeTransaction = async <
   TAbi extends Abi,
   TFunctionName extends ExtractAbiFunctionNames<
     TAbi,
     "nonpayable" | "payable"
-  > = string,
+  > = string
 >({
   engine,
   chainId,
@@ -77,8 +83,8 @@ export const writeTransaction = async <
         args,
       },
       null,
-      2,
-    ),
+      2
+    )
   );
 
   const parsedTxOverrides = parseTxOverrides(txOverrides);
@@ -97,7 +103,7 @@ export const writeTransaction = async <
     },
     simulateTransaction,
     idempotencyKey,
-    smartAccountAddress,
+    smartAccountAddress
   );
   return result;
 };


### PR DESCRIPTION
- Add `parseTxOverrides` utils function that strips out invalid values from `txOverrides`
- Adds it to wherever `txOverrides` is being used
- Added unit test