### PR TITLE
add support for custom auth server

### DIFF
--- a/.changeset/empty-planets-float.md
+++ b/.changeset/empty-planets-float.md
@@ -1,0 +1,5 @@
+---
+"@treasure-dev/tdk-react": patch
+---
+
+Updated to handle attempts to log in with custom auth endpoint

--- a/.changeset/orange-turkeys-walk.md
+++ b/.changeset/orange-turkeys-walk.md
@@ -1,0 +1,5 @@
+---
+"@treasure-dev/tdk-core": patch
+---
+
+Added support for login with custom auth endpoint

--- a/apps/api/src/schema/auth.ts
+++ b/apps/api/src/schema/auth.ts
@@ -49,9 +49,21 @@ export const loginReplySchema = Type.Object({
   ]),
 });
 
+export const loginCustomBodySchema = Type.Object({
+  payload: Type.String(),
+});
+
+export const loginCustomReplySchema = Type.Object({
+  userId: Type.String(),
+  email: Type.String(),
+  exp: Type.Number(),
+});
+
 export type ReadLoginPayloadQuerystring = Static<
   typeof readLoginPayloadQuerystringSchema
 >;
 export type ReadLoginPayloadReply = Static<typeof readLoginPayloadReplySchema>;
 export type LoginBody = Static<typeof loginBodySchema>;
 export type LoginReply = Static<typeof loginReplySchema>;
+export type LoginCustomBody = Static<typeof loginCustomBodySchema>;
+export type LoginCustomReply = Static<typeof loginCustomReplySchema>;

--- a/apps/api/src/utils/wanderers.ts
+++ b/apps/api/src/utils/wanderers.ts
@@ -1,0 +1,35 @@
+import type { LoginCustomReply } from "../schema";
+
+const WANDERERS_API_URL = "https://id.wanderers.ai/sessions/whoami";
+
+type WanderersSession = {
+  active: boolean;
+  expires_at: string;
+  identity: {
+    id: string;
+    traits: {
+      email: string;
+    };
+  };
+};
+
+export const validateWanderersUser = async (
+  cookie?: string,
+  token?: string,
+): Promise<LoginCustomReply | undefined> => {
+  const response = await fetch(WANDERERS_API_URL, {
+    headers: cookie ? { Cookie: cookie } : { "X-Session-Token": token ?? "" },
+  });
+
+  const session: WanderersSession = await response.json();
+  const expiresAt = new Date(session.expires_at).getTime();
+  if (!session.active || expiresAt < Date.now()) {
+    return undefined;
+  }
+
+  return {
+    userId: session.identity.id,
+    email: session.identity.traits.email,
+    exp: Math.floor(expiresAt / 1000),
+  };
+};

--- a/examples/connect-core/src/main.ts
+++ b/examples/connect-core/src/main.ts
@@ -57,6 +57,27 @@ document.querySelector<HTMLDivElement>("#app")!.innerHTML = `
           </button>
         </div>
       </div>
+      <p>
+        or
+      </p>
+      <div id="custom-auth-container">
+        <h2>Connect with Custom Auth</h2>
+        <div>
+          <input
+            id="custom-auth-key"
+            type="text"
+            placeholder="Auth key name"
+          />
+          <input
+            id="custom-auth-value"
+            type="text"
+            placeholder="Auth value"
+          />
+          <button type="button">
+            Connect
+          </button>
+        </div>
+      </div>
     </div>
     <div id="user-container">
       <h2>Logged in as <span id="user-email" /></h2>
@@ -86,6 +107,13 @@ document.querySelector<HTMLDivElement>("#app")!.innerHTML = `
   const emailButton = emailContainer.querySelector<HTMLButtonElement>("button");
   const codeInput = codeContainer.querySelector<HTMLInputElement>("input")!;
   const codeButton = codeContainer.querySelector<HTMLButtonElement>("button");
+  const customAuthKeyInput =
+    document.querySelector<HTMLInputElement>("#custom-auth-key")!;
+  const customAuthValueInput =
+    document.querySelector<HTMLInputElement>("#custom-auth-value")!;
+  const customAuthButton = document.querySelector<HTMLButtonElement>(
+    "#custom-auth-container button",
+  );
   const mintButton = userContainer.querySelector<HTMLButtonElement>("#mint");
   const logOutButton =
     userContainer.querySelector<HTMLButtonElement>("#log-out");
@@ -167,6 +195,34 @@ document.querySelector<HTMLDivElement>("#app")!.innerHTML = `
     }
 
     codeButton.disabled = false;
+  });
+
+  // Set up Connect with Custom Auth flow
+  customAuthButton?.addEventListener("click", async () => {
+    customAuthButton.disabled = true;
+    try {
+      const result = await logIn({
+        client,
+        ecosystemId: import.meta.env.VITE_TDK_ECOSYSTEM_ID,
+        ecosystemPartnerId: import.meta.env.VITE_TDK_ECOSYSTEM_PARTNER_ID,
+        method: "auth_endpoint",
+        payload: JSON.stringify({
+          [customAuthKeyInput.value]: customAuthValueInput.value,
+        }),
+        apiUri,
+        chainId,
+        sessionOptions,
+      });
+      tdk = result.tdk;
+      user = result.user;
+      userEmail.innerHTML = user.email || user.id;
+      connectContainer.hidden = true;
+      userContainer.hidden = false;
+    } catch (err) {
+      console.error("Error logging in with email:", err);
+    }
+
+    customAuthButton.disabled = false;
   });
 
   // Set up Mint button

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dev:launcher": "pnpm --filter ./packages/launcher dev",
     "dev:api": "pnpm --filter ./apps/api dev",
     "dev:react": "pnpm --filter ./packages/react dev",
+    "dev:connect-core": "pnpm --filter ./examples/connect-core dev",
     "dev:connect-electron": "pnpm --filter ./examples/connect-electron dev",
     "dev:connect-react": "pnpm --filter ./examples/connect-react dev",
     "start:api": "pnpm --filter ./apps/api start",

--- a/packages/core/src/connect/login.ts
+++ b/packages/core/src/connect/login.ts
@@ -47,7 +47,8 @@ export type ConnectMethod =
   | (typeof SUPPORTED_SOCIAL_OPTIONS)[number]
   | "email"
   | "passkey"
-  | "wallet";
+  | "wallet"
+  | "auth_endpoint";
 
 type ConnectWalletConfig = {
   client: TreasureConnectClient;
@@ -69,6 +70,10 @@ type ConnectWalletConfig = {
       method: "passkey";
       passkeyName?: string;
       hasStoredPasskey?: boolean;
+    }
+  | {
+      method: "auth_endpoint";
+      payload: string;
     }
 );
 
@@ -114,6 +119,15 @@ export const connectEcosystemWallet = async (params: ConnectWalletConfig) => {
       strategy: "passkey",
       type: hasPasskey ? "sign-in" : "sign-up",
       passkeyName: params.passkeyName,
+    });
+  } else if (params.method === "auth_endpoint") {
+    // Connect with auth endpoint
+    await wallet.connect({
+      client,
+      chain,
+      strategy: "auth_endpoint",
+      payload: params.payload,
+      encryptionKey: "any", // Unused with enclave ecosystem wallets
     });
   } else {
     // Connect with social
@@ -214,7 +228,11 @@ export const logIn = async (params: ConnectWalletConfig & ConnectConfig) => {
     ...connectWalletParams
   } = params;
 
-  const wallet = await connectWallet({ client, ...connectWalletParams });
+  const wallet = await connectWallet({
+    client,
+    chainId,
+    ...connectWalletParams,
+  });
 
   const tdk = new TDKAPI({
     baseUri: apiUri,

--- a/packages/react/src/components/connect/ConnectModal.tsx
+++ b/packages/react/src/components/connect/ConnectModal.tsx
@@ -214,6 +214,10 @@ export const ConnectModal = ({
         setError(err);
         onConnectError?.(method, err);
       }
+    } else if (method === "auth_endpoint") {
+      throw new Error(
+        "Auth endpoint not supported in Treasure Connect modal. Use TDK Core package to connect.",
+      );
     } else {
       // Handle connecting with social / passkey
       try {


### PR DESCRIPTION
- Adds support for connecting with the [Thirdweb Custom Auth Server](https://portal.thirdweb.com/connect/in-app-wallet/custom-auth/configuration) feature
- Handles Wanderers cookies and session tokens with intention to switch to JWT in the future