### PR TITLE
api: update login endpoint to detect possible user migrations

### DIFF
--- a/apps/api/prisma/migrations/20241105213123_legacy_profile_updates/migration.sql
+++ b/apps/api/prisma/migrations/20241105213123_legacy_profile_updates/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "public"."user_profile" ADD COLUMN     "legacy_profile_migrated_at" TIMESTAMP(3);
+
+-- CreateIndex
+CREATE INDEX "user_profile_legacy_email_legacy_email_verified_at_idx" ON "public"."user_profile"("legacy_email", "legacy_email_verified_at");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -93,9 +93,10 @@ model UserProfile {
   showGemsBalance  Boolean @default(true) @map("show_gems_balance")
 
   // Migration
-  legacyAddress         String?   @unique @map("legacy_address") @db.VarChar(42)
-  legacyEmail           String?   @map("legacy_email")
-  legacyEmailVerifiedAt DateTime? @map("legacy_email_verified_at")
+  legacyAddress           String?   @unique @map("legacy_address") @db.VarChar(42)
+  legacyEmail             String?   @map("legacy_email")
+  legacyEmailVerifiedAt   DateTime? @map("legacy_email_verified_at")
+  legacyProfileMigratedAt DateTime? @map("legacy_profile_migrated_at")
 
   // Status
   testnetFaucetLastUsedAt DateTime? @map("testnet_faucet_last_used_at")
@@ -109,6 +110,7 @@ model UserProfile {
   updatedAt DateTime @updatedAt @map("updated_at")
 
   @@index([legacyAddress])
+  @@index([legacyEmail, legacyEmailVerifiedAt])
   @@index([tag])
   @@map("user_profile")
   @@schema("public")

--- a/apps/api/src/schema/auth.ts
+++ b/apps/api/src/schema/auth.ts
@@ -3,6 +3,7 @@ import {
   EXAMPLE_WALLET_ADDRESS,
   sessionSchema,
   userProfileSchema,
+  userPublicProfileSchema,
   userSchema,
 } from "./shared";
 
@@ -45,6 +46,14 @@ export const loginReplySchema = Type.Object({
       sessions: Type.Array(sessionSchema),
     }),
   ]),
+  legacyProfiles: Type.Array(
+    Type.Intersect([
+      Type.Object({
+        id: Type.String(),
+      }),
+      userPublicProfileSchema,
+    ]),
+  ),
 });
 
 export const loginCustomBodySchema = Type.Object({


### PR DESCRIPTION
Updates the `POST /login` endpoint to return a new field `legacyProfiles` that contains any possible user migrations from the legacy system that could be present based on the email or EOA address that was used to create the smart account