### PR TITLE
[bugfix] disable analytics manager on SSR

### DIFF
--- a/.changeset/cold-singers-teach.md
+++ b/.changeset/cold-singers-teach.md
@@ -1,0 +1,6 @@
+---
+"@treasure-dev/tdk-react": patch
+"@treasure-dev/tdk-core": patch
+---
+
+Remove analytics manager from SSR

--- a/packages/core/src/analytics/AnalyticsManager.ts
+++ b/packages/core/src/analytics/AnalyticsManager.ts
@@ -52,6 +52,10 @@ export class AnalyticsManager {
     cartridgeTag: string;
     device?: Device;
   }) {
+    if (this.initialized) {
+      throw new Error("AnalyticsManager is already initialized");
+    }
+
     this.apiUri = apiUri;
     this.apiKey = apiKey;
     this.app = app;

--- a/packages/core/src/analytics/storage.ts
+++ b/packages/core/src/analytics/storage.ts
@@ -1,6 +1,18 @@
 import { v4 as uuidv4 } from "uuid";
 import type { AnalyticsPayload } from "./types";
 
+const localStorage: Pick<
+  WindowLocalStorage["localStorage"],
+  "getItem" | "setItem" | "removeItem"
+> =
+  typeof window !== "undefined"
+    ? window.localStorage
+    : {
+        getItem: () => null,
+        setItem: () => null,
+        removeItem: () => null,
+      };
+
 function getCachedEventIds(): string[] {
   let cachedEventIds: string[] = [];
   const cachedEventIdsValue = localStorage.getItem("tdk-analytics-event-ids");
@@ -35,7 +47,7 @@ export function addCachedEvent(event: AnalyticsPayload): void {
   cachedEventIds.push(event.id);
   localStorage.setItem(
     "tdk-analytics-event-ids",
-    JSON.stringify(cachedEventIds),
+    JSON.stringify(cachedEventIds)
   );
   localStorage.setItem(`tdk-analytic-${event.id}`, JSON.stringify(event));
 }

--- a/packages/core/src/analytics/storage.ts
+++ b/packages/core/src/analytics/storage.ts
@@ -47,7 +47,7 @@ export function addCachedEvent(event: AnalyticsPayload): void {
   cachedEventIds.push(event.id);
   localStorage.setItem(
     "tdk-analytics-event-ids",
-    JSON.stringify(cachedEventIds)
+    JSON.stringify(cachedEventIds),
   );
   localStorage.setItem(`tdk-analytic-${event.id}`, JSON.stringify(event));
 }

--- a/packages/react/src/contexts/treasure.tsx
+++ b/packages/react/src/contexts/treasure.tsx
@@ -104,6 +104,8 @@ const TreasureProviderInner = ({
       }),
     [apiUri, chain.id, sessionOptions?.backendWallet, client],
   );
+  const [analyticsManager, setAnalyticsManager] =
+    useState<AnalyticsManager | null>(null);
 
   const contractAddresses = useMemo(
     () => getContractAddresses(chain.id),
@@ -114,9 +116,9 @@ const TreasureProviderInner = ({
     ? (getUserAddress(user, chain.id) ?? user.smartAccounts[0]?.address)
     : undefined;
 
-  const analyticsManager = useMemo(() => {
+  useEffect(() => {
     if (!analyticsOptions) {
-      return undefined;
+      return;
     }
 
     AnalyticsManager.instance.init({
@@ -127,7 +129,7 @@ const TreasureProviderInner = ({
       device: analyticsOptions.device,
     });
 
-    return AnalyticsManager.instance;
+    setAnalyticsManager(AnalyticsManager.instance);
   }, [analyticsOptions]);
 
   const trackCustomEvent = useCallback(

--- a/packages/react/src/contexts/treasure.tsx
+++ b/packages/react/src/contexts/treasure.tsx
@@ -116,8 +116,9 @@ const TreasureProviderInner = ({
     ? (getUserAddress(user, chain.id) ?? user.smartAccounts[0]?.address)
     : undefined;
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: analyticsManager doesnt need to be a dependency
   useEffect(() => {
-    if (!analyticsOptions) {
+    if (!analyticsOptions || analyticsManager) {
       return;
     }
 


### PR DESCRIPTION
Seeing this error when using this package in a node app. Think we should just be safe and not save to local storage in the even the environment doesn't support it. 

```sh
const cachedEventIdsValue = localStorage.getItem("tdk-analytics-event-ids");
                              ^
ReferenceError: localStorage is not defined
```