### PR TITLE
magicswap: add endpoints for creating swap and liquidity args

### DIFF
--- a/.changeset/rotten-candles-knock.md
+++ b/.changeset/rotten-candles-knock.md
@@ -1,0 +1,5 @@
+---
+"@treasure-dev/tdk-core": minor
+---
+
+Added helpers for fetching minimal Magicswap pool payloads

--- a/apps/api/src/routes/magicswap.ts
+++ b/apps/api/src/routes/magicswap.ts
@@ -176,27 +176,29 @@ export const magicswapRoutes =
         },
       },
       async (req, reply) => {
-        const { authError, body, chain } = req;
+        const {
+          authError,
+          body: {
+            tokenInId,
+            tokenOutId,
+            amountIn,
+            amountOut,
+            path,
+            nftsIn,
+            nftsOut,
+            isExactOut,
+            slippage,
+            backendWallet = req.backendWallet,
+            simulateTransaction = env.ENGINE_TRANSACTION_SIMULATION_ENABLED,
+          },
+          chain,
+        } = req;
         const userAddress = req.backendUserAddress ?? req.userAddress;
 
         if (!userAddress) {
           throwUnauthorizedError(authError);
           return;
         }
-
-        const {
-          tokenInId,
-          tokenOutId,
-          amountIn,
-          amountOut,
-          path,
-          nftsIn,
-          nftsOut,
-          isExactOut,
-          slippage,
-          backendWallet = req.backendWallet,
-          simulateTransaction = env.ENGINE_TRANSACTION_SIMULATION_ENABLED,
-        } = body;
 
         if (!backendWallet) {
           throwForbiddenBackendWalletError();
@@ -371,24 +373,27 @@ export const magicswapRoutes =
         },
       },
       async (req, reply) => {
-        const { authError, body, chain, params } = req;
+        const {
+          authError,
+          body: {
+            amount0,
+            amount1,
+            amount0Min,
+            amount1Min,
+            nfts0,
+            nfts1,
+            backendWallet = req.backendWallet,
+            simulateTransaction = env.ENGINE_TRANSACTION_SIMULATION_ENABLED,
+          },
+          chain,
+          params,
+        } = req;
         const userAddress = req.backendUserAddress ?? req.userAddress;
 
         if (!userAddress) {
           throwUnauthorizedError(authError);
           return;
         }
-
-        const {
-          amount0,
-          amount1,
-          amount0Min,
-          amount1Min,
-          nfts0,
-          nfts1,
-          backendWallet = req.backendWallet,
-          simulateTransaction = env.ENGINE_TRANSACTION_SIMULATION_ENABLED,
-        } = body;
 
         if (!backendWallet) {
           throwForbiddenBackendWalletError();
@@ -541,24 +546,27 @@ export const magicswapRoutes =
         },
       },
       async (req, reply) => {
-        const { authError, body, chain, params } = req;
+        const {
+          authError,
+          body: {
+            amountLP,
+            amount0Min,
+            amount1Min,
+            nfts0,
+            nfts1,
+            swapLeftover = true,
+            backendWallet = req.backendWallet,
+            simulateTransaction = env.ENGINE_TRANSACTION_SIMULATION_ENABLED,
+          },
+          chain,
+          params,
+        } = req;
         const userAddress = req.backendUserAddress ?? req.userAddress;
 
         if (!userAddress) {
           throwUnauthorizedError(authError);
           return;
         }
-
-        const {
-          amountLP,
-          amount0Min,
-          amount1Min,
-          nfts0,
-          nfts1,
-          swapLeftover = true,
-          backendWallet = req.backendWallet,
-          simulateTransaction = env.ENGINE_TRANSACTION_SIMULATION_ENABLED,
-        } = body;
 
         if (!backendWallet) {
           throwForbiddenBackendWalletError();

--- a/apps/api/src/routes/magicswap.ts
+++ b/apps/api/src/routes/magicswap.ts
@@ -190,10 +190,18 @@ export const magicswapRoutes =
             nftsOut,
             isExactOut,
             slippage,
-            toAddress,
+            toAddress = req.userAddress,
           },
           chain,
         } = req;
+
+        if (!toAddress) {
+          throw new TdkError({
+            name: TDK_ERROR_NAMES.MagicswapError,
+            code: TDK_ERROR_CODES.MAGICSWAP_SWAP_FAILED,
+            message: "No toAddress provided",
+          });
+        }
 
         const pools = await fetchPoolsForSwap({ chainId: chain.id });
         const poolTokens = pools
@@ -260,6 +268,7 @@ export const magicswapRoutes =
             nftsOut,
             isExactOut,
             slippage,
+            toAddress,
             backendWallet = req.backendWallet,
             simulateTransaction = env.ENGINE_TRANSACTION_SIMULATION_ENABLED,
           },
@@ -306,7 +315,7 @@ export const magicswapRoutes =
           value,
         } = createSwapArgs({
           chainId: chain.id,
-          toAddress: userAddress,
+          toAddress: (toAddress as Address | undefined) ?? userAddress,
           tokenIn,
           tokenOut,
           nftsIn,
@@ -372,11 +381,19 @@ export const magicswapRoutes =
             amount1Min,
             nfts0,
             nfts1,
-            toAddress,
+            toAddress = req.userAddress,
           },
           chain,
           params,
         } = req;
+
+        if (!toAddress) {
+          throw new TdkError({
+            name: TDK_ERROR_NAMES.MagicswapError,
+            code: TDK_ERROR_CODES.MAGICSWAP_ADD_LIQUIDITY_FAILED,
+            message: "No toAddress provided",
+          });
+        }
 
         try {
           const pool = await fetchPoolForLiquidity({
@@ -435,6 +452,7 @@ export const magicswapRoutes =
             amount1Min,
             nfts0,
             nfts1,
+            toAddress,
             backendWallet = req.backendWallet,
             simulateTransaction = env.ENGINE_TRANSACTION_SIMULATION_ENABLED,
           },
@@ -474,7 +492,7 @@ export const magicswapRoutes =
           value,
         } = createAddLiquidityArgs({
           chainId: chain.id,
-          toAddress: userAddress,
+          toAddress: (toAddress as Address | undefined) ?? userAddress,
           amount0: amount0 ? BigInt(amount0) : undefined,
           amount1: amount1 ? BigInt(amount1) : undefined,
           amount0Min: amount0Min ? BigInt(amount0Min) : undefined,
@@ -538,11 +556,19 @@ export const magicswapRoutes =
             nfts0,
             nfts1,
             swapLeftover = true,
-            toAddress,
+            toAddress = req.userAddress,
           },
           chain,
           params,
         } = req;
+
+        if (!toAddress) {
+          throw new TdkError({
+            name: TDK_ERROR_NAMES.MagicswapError,
+            code: TDK_ERROR_CODES.MAGICSWAP_REMOVE_LIQUIDITY_FAILED,
+            message: "No toAddress provided",
+          });
+        }
 
         try {
           const pool = await fetchPoolForLiquidity({
@@ -601,6 +627,7 @@ export const magicswapRoutes =
             nfts0,
             nfts1,
             swapLeftover = true,
+            toAddress,
             backendWallet = req.backendWallet,
             simulateTransaction = env.ENGINE_TRANSACTION_SIMULATION_ENABLED,
           },
@@ -640,7 +667,7 @@ export const magicswapRoutes =
           value,
         } = createRemoveLiquidityArgs({
           chainId: chain.id,
-          toAddress: userAddress,
+          toAddress: (toAddress as Address | undefined) ?? userAddress,
           amountLP: BigInt(amountLP),
           amount0Min: BigInt(amount0Min),
           amount1Min: BigInt(amount1Min),

--- a/apps/api/src/schema/magicswap.ts
+++ b/apps/api/src/schema/magicswap.ts
@@ -192,7 +192,7 @@ const nftInputSchema = Type.Object({
   quantity: Type.Number({ description: "The quantity of the NFT" }),
 });
 
-const swapBaseBodySchema = Type.Object({
+export const swapArgsBodySchema = Type.Object({
   tokenInId: Type.String({
     description: "The unique identifier of the `in` token",
   }),
@@ -212,24 +212,20 @@ const swapBaseBodySchema = Type.Object({
     Type.Array(nftInputSchema, { description: "Array of NFTs to swap out" }),
   ),
   slippage: Type.Optional(Type.Number({ description: "Slippage tolerance" })),
+  toAddress: Type.Optional(
+    Type.String({ description: "Address to send tokens" }),
+  ),
 });
 
-export const swapArgsBodySchema = Type.Intersect([
-  swapBaseBodySchema,
-  Type.Object({
-    toAddress: Type.String({ description: "Address to send tokens" }),
-  }),
-]);
-
 export const swapBodySchema = Type.Intersect([
-  swapBaseBodySchema,
+  swapArgsBodySchema,
   Type.Object({
     backendWallet: Type.Optional(Type.String()),
     simulateTransaction: Type.Optional(Type.Boolean()),
   }),
 ]);
 
-const addLiquidityBaseBodySchema = Type.Object({
+export const addLiquidityArgsBodySchema = Type.Object({
   nfts0: Type.Optional(
     Type.Array(nftInputSchema, { description: "Array of NFTs for token0" }),
   ),
@@ -244,24 +240,20 @@ const addLiquidityBaseBodySchema = Type.Object({
   amount1Min: Type.Optional(
     Type.String({ description: "Minimum amount for token1" }),
   ),
+  toAddress: Type.Optional(
+    Type.String({ description: "Address to send LP tokens" }),
+  ),
 });
 
-export const addLiquidityArgsBodySchema = Type.Intersect([
-  addLiquidityBaseBodySchema,
-  Type.Object({
-    toAddress: Type.String({ description: "Address to send LP tokens" }),
-  }),
-]);
-
 export const addLiquidityBodySchema = Type.Intersect([
-  addLiquidityBaseBodySchema,
+  addLiquidityArgsBodySchema,
   Type.Object({
     backendWallet: Type.Optional(Type.String()),
     simulateTransaction: Type.Optional(Type.Boolean()),
   }),
 ]);
 
-const removeLiquidityBaseBodySchema = Type.Object({
+export const removeLiquidityArgsBodySchema = Type.Object({
   nfts0: Type.Optional(
     Type.Array(nftInputSchema, { description: "Array of NFTs for token0" }),
   ),
@@ -277,17 +269,13 @@ const removeLiquidityBaseBodySchema = Type.Object({
       description: "Boolean indicating if swap leftover",
     }),
   ),
+  toAddress: Type.Optional(
+    Type.String({ description: "Address to send tokens" }),
+  ),
 });
 
-export const removeLiquidityArgsBodySchema = Type.Intersect([
-  removeLiquidityBaseBodySchema,
-  Type.Object({
-    toAddress: Type.String({ description: "Address to send tokens" }),
-  }),
-]);
-
 export const removeLiquidityBodySchema = Type.Intersect([
-  removeLiquidityBaseBodySchema,
+  removeLiquidityArgsBodySchema,
   Type.Object({
     backendWallet: Type.Optional(Type.String()),
     simulateTransaction: Type.Optional(Type.Boolean()),

--- a/apps/api/src/schema/magicswap.ts
+++ b/apps/api/src/schema/magicswap.ts
@@ -1,5 +1,14 @@
 import { type Static, Type } from "@sinclair/typebox";
 
+export const contractArgsReplySchema = Type.Object({
+  address: Type.String({ description: "Contract address to call" }),
+  functionName: Type.String({ description: "Function name to call" }),
+  args: Type.Any({ description: "Arguments to call on the function" }),
+  value: Type.Optional(
+    Type.String({ description: "Value to send with call, if applicable" }),
+  ),
+});
+
 // Define the schema for VaultCollections with descriptions
 const vaultCollectionSchema = Type.Object(
   {
@@ -183,7 +192,7 @@ const nftInputSchema = Type.Object({
   quantity: Type.Number({ description: "The quantity of the NFT" }),
 });
 
-export const swapBodySchema = Type.Object({
+const swapBaseBodySchema = Type.Object({
   tokenInId: Type.String({
     description: "The unique identifier of the `in` token",
   }),
@@ -203,9 +212,22 @@ export const swapBodySchema = Type.Object({
     Type.Array(nftInputSchema, { description: "Array of NFTs to swap out" }),
   ),
   slippage: Type.Optional(Type.Number({ description: "Slippage tolerance" })),
-  backendWallet: Type.Optional(Type.String()),
-  simulateTransaction: Type.Optional(Type.Boolean()),
 });
+
+export const swapArgsBodySchema = Type.Intersect([
+  swapBaseBodySchema,
+  Type.Object({
+    toAddress: Type.String({ description: "Address to send tokens" }),
+  }),
+]);
+
+export const swapBodySchema = Type.Intersect([
+  swapBaseBodySchema,
+  Type.Object({
+    backendWallet: Type.Optional(Type.String()),
+    simulateTransaction: Type.Optional(Type.Boolean()),
+  }),
+]);
 
 const addLiquidityBaseBodySchema = Type.Object({
   nfts0: Type.Optional(
@@ -230,15 +252,6 @@ export const addLiquidityArgsBodySchema = Type.Intersect([
     toAddress: Type.String({ description: "Address to send LP tokens" }),
   }),
 ]);
-
-export const addLiquidityArgsReplySchema = Type.Object({
-  address: Type.String({ description: "Contract address to call" }),
-  functionName: Type.String({ description: "Function name to call" }),
-  args: Type.Any({ description: "Arguments to call on the function" }),
-  value: Type.Optional(
-    Type.String({ description: "Value to send with call, if applicable" }),
-  ),
-});
 
 export const addLiquidityBodySchema = Type.Intersect([
   addLiquidityBaseBodySchema,
@@ -273,15 +286,6 @@ export const removeLiquidityArgsBodySchema = Type.Intersect([
   }),
 ]);
 
-export const removeLiquidityArgsReplySchema = Type.Object({
-  address: Type.String({ description: "Contract address to call" }),
-  functionName: Type.String({ description: "Function name to call" }),
-  args: Type.Any({ description: "Arguments to call on the function" }),
-  value: Type.Optional(
-    Type.String({ description: "Value to send with call, if applicable" }),
-  ),
-});
-
 export const removeLiquidityBodySchema = Type.Intersect([
   removeLiquidityBaseBodySchema,
   Type.Object({
@@ -294,6 +298,8 @@ const poolParamsSchema = Type.Object({
   id: Type.String(),
 });
 
+export type ContractArgsReply = Static<typeof contractArgsReplySchema>;
+
 export type PoolsReply = Static<typeof poolsReplySchema>;
 
 export type PoolParams = Static<typeof poolParamsSchema>;
@@ -302,16 +308,13 @@ export type PoolReply = Static<typeof poolReplySchema>;
 export type RouteBody = Static<typeof routeBodySchema>;
 export type RouteReply = Static<typeof routeReplySchema>;
 
+export type SwapArgsBody = Static<typeof swapArgsBodySchema>;
 export type SwapBody = Static<typeof swapBodySchema>;
 
 export type AddLiquidityArgsBody = Static<typeof addLiquidityArgsBodySchema>;
-export type AddLiquidityArgsReply = Static<typeof addLiquidityArgsReplySchema>;
 export type AddLiquidityBody = Static<typeof addLiquidityBodySchema>;
 
 export type RemoveLiquidityArgsBody = Static<
   typeof removeLiquidityArgsBodySchema
->;
-export type RemoveLiquidityArgsReply = Static<
-  typeof removeLiquidityArgsReplySchema
 >;
 export type RemoveLiquidityBody = Static<typeof removeLiquidityBodySchema>;

--- a/apps/api/src/schema/magicswap.ts
+++ b/apps/api/src/schema/magicswap.ts
@@ -207,7 +207,7 @@ export const swapBodySchema = Type.Object({
   simulateTransaction: Type.Optional(Type.Boolean()),
 });
 
-export const addLiquidityBodySchema = Type.Object({
+const addLiquidityBaseBodySchema = Type.Object({
   nfts0: Type.Optional(
     Type.Array(nftInputSchema, { description: "Array of NFTs for token0" }),
   ),
@@ -222,11 +222,33 @@ export const addLiquidityBodySchema = Type.Object({
   amount1Min: Type.Optional(
     Type.String({ description: "Minimum amount for token1" }),
   ),
-  backendWallet: Type.Optional(Type.String()),
-  simulateTransaction: Type.Optional(Type.Boolean()),
 });
 
-export const removeLiquidityBodySchema = Type.Object({
+export const addLiquidityArgsBodySchema = Type.Intersect([
+  addLiquidityBaseBodySchema,
+  Type.Object({
+    toAddress: Type.String({ description: "Address to send LP tokens" }),
+  }),
+]);
+
+export const addLiquidityArgsReplySchema = Type.Object({
+  address: Type.String({ description: "Contract address to call" }),
+  functionName: Type.String({ description: "Function name to call" }),
+  args: Type.Any({ description: "Arguments to call on the function" }),
+  value: Type.Optional(
+    Type.String({ description: "Value to send with call, if applicable" }),
+  ),
+});
+
+export const addLiquidityBodySchema = Type.Intersect([
+  addLiquidityBaseBodySchema,
+  Type.Object({
+    backendWallet: Type.Optional(Type.String()),
+    simulateTransaction: Type.Optional(Type.Boolean()),
+  }),
+]);
+
+const removeLiquidityBaseBodySchema = Type.Object({
   nfts0: Type.Optional(
     Type.Array(nftInputSchema, { description: "Array of NFTs for token0" }),
   ),
@@ -242,9 +264,31 @@ export const removeLiquidityBodySchema = Type.Object({
       description: "Boolean indicating if swap leftover",
     }),
   ),
-  backendWallet: Type.Optional(Type.String()),
-  simulateTransaction: Type.Optional(Type.Boolean()),
 });
+
+export const removeLiquidityArgsBodySchema = Type.Intersect([
+  removeLiquidityBaseBodySchema,
+  Type.Object({
+    toAddress: Type.String({ description: "Address to send tokens" }),
+  }),
+]);
+
+export const removeLiquidityArgsReplySchema = Type.Object({
+  address: Type.String({ description: "Contract address to call" }),
+  functionName: Type.String({ description: "Function name to call" }),
+  args: Type.Any({ description: "Arguments to call on the function" }),
+  value: Type.Optional(
+    Type.String({ description: "Value to send with call, if applicable" }),
+  ),
+});
+
+export const removeLiquidityBodySchema = Type.Intersect([
+  removeLiquidityBaseBodySchema,
+  Type.Object({
+    backendWallet: Type.Optional(Type.String()),
+    simulateTransaction: Type.Optional(Type.Boolean()),
+  }),
+]);
 
 const poolParamsSchema = Type.Object({
   id: Type.String(),
@@ -260,5 +304,14 @@ export type RouteReply = Static<typeof routeReplySchema>;
 
 export type SwapBody = Static<typeof swapBodySchema>;
 
+export type AddLiquidityArgsBody = Static<typeof addLiquidityArgsBodySchema>;
+export type AddLiquidityArgsReply = Static<typeof addLiquidityArgsReplySchema>;
 export type AddLiquidityBody = Static<typeof addLiquidityBodySchema>;
+
+export type RemoveLiquidityArgsBody = Static<
+  typeof removeLiquidityArgsBodySchema
+>;
+export type RemoveLiquidityArgsReply = Static<
+  typeof removeLiquidityArgsReplySchema
+>;
 export type RemoveLiquidityBody = Static<typeof removeLiquidityBodySchema>;

--- a/packages/core/src/magicswap/index.ts
+++ b/packages/core/src/magicswap/index.ts
@@ -1,4 +1,8 @@
 export { fetchPools, fetchPool } from "./pools";
 export { createRoute } from "./route";
-export { createSwapArgs } from "./swap";
-export { createAddLiquidityArgs, createRemoveLiquidityArgs } from "./liquidity";
+export { fetchPoolsForSwap, createSwapArgs } from "./swap";
+export {
+  fetchPoolForLiquidity,
+  createAddLiquidityArgs,
+  createRemoveLiquidityArgs,
+} from "./liquidity";

--- a/packages/core/src/magicswap/liquidity.ts
+++ b/packages/core/src/magicswap/liquidity.ts
@@ -6,6 +6,7 @@ import type {
 import type { magicswapV2RouterAbi } from "../abis/magicswapV2RouterAbi";
 import type { AddressString } from "../types";
 import { getContractAddresses } from "../utils/contracts";
+import { createPoolFromPair, fetchPair } from "./pools";
 import type { NFTInput } from "./types";
 
 type AddLiquidityFunctionName =
@@ -35,6 +36,18 @@ type LiquidityPool = {
   token1: LiquidityPoolToken;
   hasNFT: boolean;
   isNFTNFT: boolean;
+};
+
+export const fetchPoolForLiquidity = async ({
+  chainId,
+  pairId,
+}: { chainId: number; pairId: string }): Promise<LiquidityPool> => {
+  const pair = await fetchPair({ chainId, pairId });
+  if (!pair) {
+    throw new Error(`Pool ${pairId} not found on chain ${chainId}`);
+  }
+
+  return createPoolFromPair(pair);
 };
 
 export const createAddLiquidityArgs = ({

--- a/packages/core/src/magicswap/pools.ts
+++ b/packages/core/src/magicswap/pools.ts
@@ -15,7 +15,7 @@ import type {
   TokensByCollectionMap,
 } from "./types";
 
-const fetchPairs = async ({ chainId }: { chainId: number }) => {
+export const fetchPairs = async ({ chainId }: { chainId: number }) => {
   const apiUrl = MAGICSWAPV2_API_URL[chainId];
   if (!apiUrl) {
     throw new Error(`No API configured for chain ${chainId}`);
@@ -34,7 +34,7 @@ const fetchPairs = async ({ chainId }: { chainId: number }) => {
   return pairs;
 };
 
-const fetchPair = async ({
+export const fetchPair = async ({
   chainId,
   pairId,
 }: { chainId: number; pairId: string }) => {
@@ -277,11 +277,11 @@ const createPoolToken = (
   };
 };
 
-const createPoolFromPair = (
+export const createPoolFromPair = (
   pair: Pair,
-  collectionsMap: CollectionsMap,
-  tokensMap: TokensByCollectionMap,
-  magicUSD: number,
+  collectionsMap: CollectionsMap = {},
+  tokensMap: TokensByCollectionMap = {},
+  magicUSD = 0,
   reserves?: [bigint, bigint],
 ) => {
   const token0 = {

--- a/packages/core/src/magicswap/swap.ts
+++ b/packages/core/src/magicswap/swap.ts
@@ -6,6 +6,7 @@ import type {
 import type { magicswapV2RouterAbi } from "../abis/magicswapV2RouterAbi";
 import type { AddressString } from "../types";
 import { getContractAddresses } from "../utils/contracts";
+import { createPoolFromPair, fetchPairs } from "./pools";
 import type { NFTInput } from "./types";
 
 type SwapFunctionName =
@@ -23,9 +24,15 @@ type SwapFunctionName =
 
 // Swap only needs a small subset of the PoolToken type
 type SwapPoolToken = {
+  id: string;
   isNFT: boolean;
   isETH: boolean;
   collectionId: string;
+};
+
+type SwapPool = {
+  token0: SwapPoolToken;
+  token1: SwapPoolToken;
 };
 
 const getAmountMax = (amount: bigint, slippage: number) =>
@@ -34,6 +41,13 @@ const getAmountMin = (amount: bigint, slippage: number) =>
   amount - (amount * BigInt(Math.ceil(slippage * 1000))) / 1000n;
 
 const DEFAULT_SLIPPAGE = 0.005;
+
+export const fetchPoolsForSwap = async ({
+  chainId,
+}: { chainId: number }): Promise<SwapPool[]> => {
+  const pairs = await fetchPairs({ chainId });
+  return pairs.map((pair) => createPoolFromPair(pair));
+};
 
 export const createSwapArgs = ({
   toAddress,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,11 +58,11 @@ catalogs:
       specifier: ^4.24.0
       version: 4.24.0
     '@sentry/node':
-      specifier: ^8.37.1
-      version: 8.37.1
+      specifier: ^8.38.0
+      version: 8.38.0
     '@sinclair/typebox':
-      specifier: ^0.33.22
-      version: 0.33.22
+      specifier: ^0.34.0
+      version: 0.34.0
     '@storybook/addon-essentials':
       specifier: ^8.4.2
       version: 8.4.2
@@ -281,16 +281,16 @@ importers:
         version: 5.1.0
       '@fastify/type-provider-typebox':
         specifier: 'catalog:'
-        version: 5.0.1(@sinclair/typebox@0.33.22)
+        version: 5.0.1(@sinclair/typebox@0.34.0)
       '@prisma/client':
         specifier: 'catalog:'
         version: 5.22.0(prisma@5.22.0)
       '@sentry/node':
         specifier: 'catalog:'
-        version: 8.37.1
+        version: 8.38.0
       '@sinclair/typebox':
         specifier: 'catalog:'
-        version: 0.33.22
+        version: 0.34.0
       '@thirdweb-dev/engine':
         specifier: 'catalog:'
         version: 0.0.16
@@ -1666,8 +1666,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
-  '@opentelemetry/instrumentation-amqplib@0.42.0':
-    resolution: {integrity: sha512-fiuU6OKsqHJiydHWgTRQ7MnIrJ2lEqsdgFtNIH4LbAUJl/5XmrIeoDzDnox+hfkgWK65jsleFuQDtYb5hW1koQ==}
+  '@opentelemetry/instrumentation-amqplib@0.43.0':
+    resolution: {integrity: sha512-ALjfQC+0dnIEcvNYsbZl/VLh7D2P1HhFF4vicRKHhHFIUV3Shpg4kXgiek5PLhmeKSIPiUB25IYH5RIneclL4A==}
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -1738,6 +1738,12 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/instrumentation-knex@0.41.0':
+    resolution: {integrity: sha512-OhI1SlLv5qnsnm2dOVrian/x3431P75GngSpnR7c4fcVFv7prXGYu29Z6ILRWJf/NJt6fkbySmwdfUUnFnHCTg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/instrumentation-koa@0.43.0':
     resolution: {integrity: sha512-lDAhSnmoTIN6ELKmLJBplXzT/Jqs5jGZehuG22EdSMaTwgjMpxMDI1YtlKEhiWPWkrz5LUsd0aOO0ZRc9vn3AQ==}
     engines: {node: '>=14'}
@@ -1788,6 +1794,12 @@ packages:
 
   '@opentelemetry/instrumentation-redis-4@0.42.0':
     resolution: {integrity: sha512-NaD+t2JNcOzX/Qa7kMy68JbmoVIV37fT/fJYzLKu2Wwd+0NCxt+K2OOsOakA8GVg8lSpFdbx4V/suzZZ2Pvdjg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-tedious@0.15.0':
+    resolution: {integrity: sha512-Kb7yo8Zsq2TUwBbmwYgTAMPK0VbhoS8ikJ6Bup9KrDtCx2JC01nCb+M0VJWXt7tl0+5jARUbKWh5jRSoImxdCw==}
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -2305,16 +2317,16 @@ packages:
   '@scure/bip39@1.4.0':
     resolution: {integrity: sha512-BEEm6p8IueV/ZTfQLp/0vhw4NPnT9oWf5+28nvmeUICjP99f4vr2d+qc7AVGDDtwRep6ifR43Yed9ERVmiITzw==}
 
-  '@sentry/core@8.37.1':
-    resolution: {integrity: sha512-82csXby589iDupM3VgCHJeWZagUyEEaDnbFcoZ/Z91QX2Sjq8FcF5OsforoXjw09i0XTFqlkFAnQVpDBmMXcpQ==}
+  '@sentry/core@8.38.0':
+    resolution: {integrity: sha512-sGD+5TEHU9G7X7zpyaoJxpOtwjTjvOd1f/MKBrWW2vf9UbYK+GUJrOzLhMoSWp/pHSYgvObkJkDb/HwieQjvhQ==}
     engines: {node: '>=14.18'}
 
-  '@sentry/node@8.37.1':
-    resolution: {integrity: sha512-ACRZmqOBHRPKsyVhnDR4+RH1QQr7WMdH7RNl62VlKNZGLvraxW1CUqTSeNUFUuOwks3P6nozROSQs8VMSC/nVg==}
+  '@sentry/node@8.38.0':
+    resolution: {integrity: sha512-nwW0XqZFQseXYn0i6i6nKPkbjgHMBEFSF9TnK6mHHqJHHObHIZ6qu5CfvGKgxATia8JPIg9NN8XcyYOnQMi07w==}
     engines: {node: '>=14.18'}
 
-  '@sentry/opentelemetry@8.37.1':
-    resolution: {integrity: sha512-P/Rp7R+qNiRYz9qtVMV12YL9CIrZjzXWGVUBZjJayHu37jdvMowCol5G850QPYy0E2O0AQnFtxBno2yeURn8QQ==}
+  '@sentry/opentelemetry@8.38.0':
+    resolution: {integrity: sha512-AfjmIf/v7+x2WplhkX66LyGKvrzzPeSgff9uJ0cFCC2s0yd1qA2VPuIwEyr5i/FOJOP5bvFr8tu/hz3LA4+F5Q==}
     engines: {node: '>=14.18'}
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
@@ -2323,16 +2335,16 @@ packages:
       '@opentelemetry/sdk-trace-base': ^1.26.0
       '@opentelemetry/semantic-conventions': ^1.27.0
 
-  '@sentry/types@8.37.1':
-    resolution: {integrity: sha512-ryMOTROLSLINKFEbHWvi7GigNrsQhsaScw2NddybJGztJQ5UhxIGESnxGxWCufBmWFDwd7+5u0jDPCVUJybp7w==}
+  '@sentry/types@8.38.0':
+    resolution: {integrity: sha512-fP5H9ZX01W4Z/EYctk3mkSHi7d06cLcX2/UWqwdWbyPWI+pL2QpUPICeO/C+8SnmYx//wFj3qWDhyPCh1PdFAA==}
     engines: {node: '>=14.18'}
 
-  '@sentry/utils@8.37.1':
-    resolution: {integrity: sha512-Qtn2IfpII12K17txG/ZtTci35XYjYi4CxbQ3j7nXY7toGv/+MqPXwV5q2i9g94XaSXlE5Wy9/hoCZoZpZs/djA==}
+  '@sentry/utils@8.38.0':
+    resolution: {integrity: sha512-3X7MgIKIx+2q5Al7QkhaRB4wV6DvzYsaeIwdqKUzGLuRjXmNgJrLoU87TAwQRmZ6Wr3IoEpThZZMNrzYPXxArw==}
     engines: {node: '>=14.18'}
 
-  '@sinclair/typebox@0.33.22':
-    resolution: {integrity: sha512-auUj4k+f4pyrIVf4GW5UKquSZFHJWri06QgARy9C0t9ZTjJLIuNIrr1yl9bWcJWJ1Gz1vOvYN1D+QPaIlNMVkQ==}
+  '@sinclair/typebox@0.34.0':
+    resolution: {integrity: sha512-BwY8C9W0/LP34i0Nzj0Xj2My0a7vBA1JGC7G0NxvQBBdHyXBf1ar27d79drRdhkgdlLhcyEpQHJKdpdoxZd+tA==}
 
   '@sindresorhus/is@4.6.0':
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
@@ -2832,6 +2844,9 @@ packages:
 
   '@types/shimmer@1.2.0':
     resolution: {integrity: sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==}
+
+  '@types/tedious@4.0.14':
+    resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -8188,9 +8203,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@fastify/type-provider-typebox@5.0.1(@sinclair/typebox@0.33.22)':
+  '@fastify/type-provider-typebox@5.0.1(@sinclair/typebox@0.34.0)':
     dependencies:
-      '@sinclair/typebox': 0.33.22
+      '@sinclair/typebox': 0.34.0
 
   '@floating-ui/core@1.6.8':
     dependencies:
@@ -8405,11 +8420,11 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.27.0
 
-  '@opentelemetry/instrumentation-amqplib@0.42.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-amqplib@0.43.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.26.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.53.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.54.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.27.0
     transitivePeerDependencies:
       - supports-color
@@ -8507,6 +8522,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@opentelemetry/instrumentation-knex@0.41.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.54.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.27.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@opentelemetry/instrumentation-koa@0.43.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -8583,6 +8606,15 @@ snapshots:
       '@opentelemetry/instrumentation': 0.53.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/redis-common': 0.36.2
       '@opentelemetry/semantic-conventions': 1.27.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-tedious@0.15.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.54.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.27.0
+      '@types/tedious': 4.0.14
     transitivePeerDependencies:
       - supports-color
 
@@ -9037,18 +9069,18 @@ snapshots:
       '@noble/hashes': 1.5.0
       '@scure/base': 1.1.9
 
-  '@sentry/core@8.37.1':
+  '@sentry/core@8.38.0':
     dependencies:
-      '@sentry/types': 8.37.1
-      '@sentry/utils': 8.37.1
+      '@sentry/types': 8.38.0
+      '@sentry/utils': 8.38.0
 
-  '@sentry/node@8.37.1':
+  '@sentry/node@8.38.0':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/context-async-hooks': 1.26.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/core': 1.26.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.54.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-amqplib': 0.42.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-amqplib': 0.43.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation-connect': 0.40.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation-dataloader': 0.12.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation-express': 0.44.0(@opentelemetry/api@1.9.0)
@@ -9060,6 +9092,7 @@ snapshots:
       '@opentelemetry/instrumentation-http': 0.53.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation-ioredis': 0.43.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation-kafkajs': 0.4.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-knex': 0.41.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation-koa': 0.43.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation-lru-memoizer': 0.40.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation-mongodb': 0.48.0(@opentelemetry/api@1.9.0)
@@ -9069,37 +9102,38 @@ snapshots:
       '@opentelemetry/instrumentation-nestjs-core': 0.40.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation-pg': 0.44.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation-redis-4': 0.42.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-tedious': 0.15.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation-undici': 0.6.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 1.26.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 1.26.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.27.0
       '@prisma/instrumentation': 5.19.1
-      '@sentry/core': 8.37.1
-      '@sentry/opentelemetry': 8.37.1(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.26.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.54.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.26.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.27.0)
-      '@sentry/types': 8.37.1
-      '@sentry/utils': 8.37.1
+      '@sentry/core': 8.38.0
+      '@sentry/opentelemetry': 8.38.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.26.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.54.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.26.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.27.0)
+      '@sentry/types': 8.38.0
+      '@sentry/utils': 8.38.0
       import-in-the-middle: 1.11.2
     transitivePeerDependencies:
       - supports-color
 
-  '@sentry/opentelemetry@8.37.1(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.26.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.54.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.26.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.27.0)':
+  '@sentry/opentelemetry@8.38.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.26.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.54.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.26.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.27.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.26.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.54.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 1.26.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.27.0
-      '@sentry/core': 8.37.1
-      '@sentry/types': 8.37.1
-      '@sentry/utils': 8.37.1
+      '@sentry/core': 8.38.0
+      '@sentry/types': 8.38.0
+      '@sentry/utils': 8.38.0
 
-  '@sentry/types@8.37.1': {}
+  '@sentry/types@8.38.0': {}
 
-  '@sentry/utils@8.37.1':
+  '@sentry/utils@8.38.0':
     dependencies:
-      '@sentry/types': 8.37.1
+      '@sentry/types': 8.38.0
 
-  '@sinclair/typebox@0.33.22': {}
+  '@sinclair/typebox@0.34.0': {}
 
   '@sindresorhus/is@4.6.0': {}
 
@@ -9724,7 +9758,7 @@ snapshots:
 
   '@types/connect@3.4.36':
     dependencies:
-      '@types/node': 22.7.8
+      '@types/node': 22.9.0
 
   '@types/debug@4.1.12':
     dependencies:
@@ -9761,7 +9795,7 @@ snapshots:
 
   '@types/mysql@2.15.26':
     dependencies:
-      '@types/node': 22.7.8
+      '@types/node': 22.9.0
 
   '@types/node@12.20.55': {}
 
@@ -9789,7 +9823,7 @@ snapshots:
 
   '@types/pg@8.6.1':
     dependencies:
-      '@types/node': 22.7.8
+      '@types/node': 22.9.0
       pg-protocol: 1.7.0
       pg-types: 2.2.0
 
@@ -9817,6 +9851,10 @@ snapshots:
       '@types/node': 22.7.8
 
   '@types/shimmer@1.2.0': {}
+
+  '@types/tedious@4.0.14':
+    dependencies:
+      '@types/node': 22.9.0
 
   '@types/trusted-types@2.0.7': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,8 +21,8 @@ catalog:
   "@radix-ui/react-dialog": ^1.1.2
   "@radix-ui/react-visually-hidden": ^1.1.0
   "@rollup/rollup-linux-x64-gnu": ^4.24.0
-  "@sentry/node": ^8.37.1
-  "@sinclair/typebox": ^0.33.22
+  "@sentry/node": ^8.38.0
+  "@sinclair/typebox": ^0.34.0
   "@storybook/addon-essentials": ^8.4.2
   "@storybook/react": ^8.4.2
   "@storybook/react-vite": ^8.4.2


### PR DESCRIPTION
Adds endpoints to the `/magicswap` API namespace for creating args for swap and add/remove liquidity functions on the server side. This allows us to off-load business logic from our in-game TDK clients like Unity, Unreal, etc.