### PR TITLE
Fix track event react

### DIFF
--- a/.changeset/pretty-keys-add.md
+++ b/.changeset/pretty-keys-add.md
@@ -1,0 +1,5 @@
+---
+"@treasure-dev/tdk-react": patch
+---
+
+Fix error where analytics failed to track event immediately on app start

--- a/examples/connect-react/src/App.tsx
+++ b/examples/connect-react/src/App.tsx
@@ -189,7 +189,7 @@ export const App = () => {
               address: nextUser
                 ? getUserAddress(nextUser, chain.id)
                 : undefined,
-              name: "wallet-connect",
+              name: "tc_connected",
               properties: {
                 method,
                 walletId: wallet.id,

--- a/examples/connect-react/src/main.tsx
+++ b/examples/connect-react/src/main.tsx
@@ -35,6 +35,7 @@ if (root) {
             app_version: "1.0.0",
             app_environment: 0,
           },
+          automaticTrackLogin: false,
           cartridgeTag: "tdk-examples-connect-react",
         }}
       >

--- a/packages/react/src/contexts/treasure.tsx
+++ b/packages/react/src/contexts/treasure.tsx
@@ -188,18 +188,20 @@ const TreasureProviderInner = ({
   });
 
   const logOut = () => {
-    trackCustomEvent({
-      name: EVT_TREASURECONNECT_DISCONNECTED,
-      properties: {
-        isUsingTreasureLauncher,
-      },
-    })
-      .then((eventId) => {
-        console.debug(`[TreasureProvider] tracked logout event: ${eventId}`);
+    if (analyticsOptions?.automaticTrackLogout !== false) {
+      trackCustomEvent({
+        name: EVT_TREASURECONNECT_DISCONNECTED,
+        properties: {
+          isUsingTreasureLauncher,
+        },
       })
-      .catch((err) => {
-        console.error(`[TreasureProvider] error tracking logout: ${err}`);
-      });
+        .then((eventId) => {
+          console.debug(`[TreasureProvider] tracked logout event: ${eventId}`);
+        })
+        .catch((err) => {
+          console.error(`[TreasureProvider] error tracking logout: ${err}`);
+        });
+    }
     setUser(undefined);
     tdk.clearAuthToken();
     tdk.clearActiveWallet();
@@ -275,18 +277,20 @@ const TreasureProviderInner = ({
     setUser(user);
     setStoredAuthToken(authToken as string);
 
-    trackCustomEvent({
-      name: EVT_TREASURECONNECT_CONNECTED,
-      properties: {
-        isUsingTreasureLauncher,
-      },
-    })
-      .then((eventId) => {
-        console.debug(`[TreasureProvider] tracked login event: ${eventId}`);
+    if (analyticsOptions?.automaticTrackLogin !== false) {
+      trackCustomEvent({
+        name: EVT_TREASURECONNECT_CONNECTED,
+        properties: {
+          isUsingTreasureLauncher,
+        },
       })
-      .catch((err) => {
-        console.error(`[TreasureProvider] error tracking login: ${err}`);
-      });
+        .then((eventId) => {
+          console.debug(`[TreasureProvider] tracked login event: ${eventId}`);
+        })
+        .catch((err) => {
+          console.error(`[TreasureProvider] error tracking login: ${err}`);
+        });
+    }
 
     // Trigger completion callback
     onConnect?.(user);

--- a/packages/react/src/contexts/treasure.tsx
+++ b/packages/react/src/contexts/treasure.tsx
@@ -107,8 +107,6 @@ const TreasureProviderInner = ({
       }),
     [apiUri, chain.id, sessionOptions?.backendWallet, client],
   );
-  const [analyticsManager, setAnalyticsManager] =
-    useState<AnalyticsManager | null>(null);
 
   const contractAddresses = useMemo(
     () => getContractAddresses(chain.id),
@@ -121,7 +119,7 @@ const TreasureProviderInner = ({
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: analyticsManager doesnt need to be a dependency
   useEffect(() => {
-    if (!analyticsOptions || analyticsManager) {
+    if (!analyticsOptions || AnalyticsManager.instance.initialized) {
       return;
     }
 
@@ -132,17 +130,12 @@ const TreasureProviderInner = ({
       cartridgeTag: analyticsOptions.cartridgeTag,
       device: analyticsOptions.device,
     });
-
-    setAnalyticsManager(AnalyticsManager.instance);
   }, [analyticsOptions]);
 
   const trackCustomEvent = useCallback(
-    async (event: AnalyticsEvent) => {
-      if (!analyticsManager) {
-        console.debug(
-          "[TreasureProvider] Cannot call trackCustomEvent because AnalyticsManager is not initialized",
-        );
-        return;
+    async (event: AnalyticsEvent): Promise<string | undefined> => {
+      if (!AnalyticsManager.instance.initialized) {
+        return undefined;
       }
 
       let address = event.address ?? userAddress;
@@ -171,9 +164,9 @@ const TreasureProviderInner = ({
         name: event.name,
         properties: event.properties ?? {},
       };
-      return analyticsManager.trackCustomEvent(trackableEvent);
+      return AnalyticsManager.instance.trackCustomEvent(trackableEvent);
     },
-    [analyticsManager, userAddress],
+    [userAddress],
   );
 
   const onAuthTokenUpdated = useCallback(
@@ -200,7 +193,13 @@ const TreasureProviderInner = ({
       properties: {
         isUsingTreasureLauncher,
       },
-    });
+    })
+      .then((eventId) => {
+        console.debug(`[TreasureProvider] tracked logout event: ${eventId}`);
+      })
+      .catch((err) => {
+        console.error(`[TreasureProvider] error tracking logout: ${err}`);
+      });
     setUser(undefined);
     tdk.clearAuthToken();
     tdk.clearActiveWallet();
@@ -281,7 +280,13 @@ const TreasureProviderInner = ({
       properties: {
         isUsingTreasureLauncher,
       },
-    });
+    })
+      .then((eventId) => {
+        console.debug(`[TreasureProvider] tracked login event: ${eventId}`);
+      })
+      .catch((err) => {
+        console.error(`[TreasureProvider] error tracking login: ${err}`);
+      });
 
     // Trigger completion callback
     onConnect?.(user);

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -32,6 +32,8 @@ type AnalyticsOptions = {
   apiUri?: string;
   apiKey: string;
   appInfo: AppInfo;
+  automaticTrackLogin?: boolean;
+  automaticTrackLogout?: boolean;
   cartridgeTag: string;
   device?: Device;
 };


### PR DESCRIPTION
- The primary change here is a fix to `trackCustomEvent` in the tdk-react where the `analyticsManager` state variable wasn't initialized when trying to call `trackCustomEvent` immediately on open. By using the singleton directly we can avoid this issue and it now works as expected
- Secondary change is that the automatic tracking for login is being called on subsequent app opens when the user is already logged in, so I've added the ability to toggle this automatic tracking off. While some developers may want that behavior we can allow developers to track this manually (like done in the react example). 
- For consistency I've also added a toggle to the automatic tracking done on logout