### PR TITLE
fix error formatting for objects

### DIFF
--- a/packages/react/src/utils/error.test.ts
+++ b/packages/react/src/utils/error.test.ts
@@ -21,7 +21,7 @@ describe("error utils", () => {
         message: '{"code":4001,"message":"test"}',
       }),
     ).toBe("test");
-    expect(getErrorMessage({})).toBe("[object Object]");
+    expect(getErrorMessage({})).toBe("{}");
     expect(getErrorMessage(7)).toBe("7");
   });
 });

--- a/packages/react/src/utils/error.ts
+++ b/packages/react/src/utils/error.ts
@@ -14,6 +14,8 @@ export const getErrorMessage = (err: unknown) => {
       } catch (_err) {
         message = outerMessage;
       }
+    } else {
+      message = JSON.stringify(err);
     }
   }
 


### PR DESCRIPTION
Should have added the stringify call in the last PR but didn't think about it until later